### PR TITLE
fix last_index() on empty wal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,17 +11,17 @@
 //! The entire log is scanned through on startup in order to detect & clean interrupted
 //! writes and determine the length of the log. It's recommended to compact the log when
 //! old entries are no longer likely to be used.
-//! 
+//!
 //! ## Usage:
-//! 
+//!
 //! ```
 //! use simple_wal::LogFile;
 //!
 //! let path = std::path::Path::new("./wal-log");
-//! 
+//!
 //! {
 //!     let mut log = LogFile::open(path).unwrap();
-//! 
+//!
 //!     // write to log
 //!     log.write(&mut b"log entry".to_vec()).unwrap();
 //!     log.write(&mut b"foobar".to_vec()).unwrap();
@@ -33,7 +33,7 @@
 //!
 //! {
 //!     let mut log = LogFile::open(path).unwrap();
-//! 
+//!
 //!     // Iterate through the log
 //!     let mut iter = log.iter(..).unwrap();
 //!     assert_eq!(iter.next().unwrap().unwrap(), b"log entry".to_vec());
@@ -57,10 +57,10 @@
 //!
 //! # let _ = std::fs::remove_file(path);
 //! ```
-//! 
-//! 
+//!
+//!
 //! ## Log Format:
-//! 
+//!
 //! ```txt
 //! 00 01 02 03 04 05 06 07|08 09 10 11 12 13 14 15|.......|-4 -3 -2 -1|
 //! -----------------------|-----------------------|-------|-----------|
@@ -71,20 +71,19 @@
 //! Numbers are stored in little-endian format.
 //!
 //! The first 8 bytes in the WAL is the starting index.
-//! 
+//!
 //! Each entry follows the following format:
 //! 1. A 64 bit unsigned int for the entry size.
 //! 2. The entry data
 //! 3. A 32 bit crc32 checksum.
 
 use advisory_lock::AdvisoryFileLock;
-use std::io::{self, Read, Write, Seek, SeekFrom};
-use std::path::PathBuf;
-use std::ops::{RangeBounds, Bound};
 use crc32fast;
 use std::convert::TryInto;
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::ops::{Bound, RangeBounds};
+use std::path::PathBuf;
 use thiserror::Error;
-
 
 /// A write-ahead-log.
 pub struct LogFile {
@@ -108,10 +107,7 @@ impl LogFile {
 
         let index = self.first_index;
 
-        Ok(LogEntry {
-            log: self,
-            index
-        })
+        Ok(LogEntry { log: self, index })
     }
 
     /// Seek to the given entry in the log
@@ -126,15 +122,23 @@ impl LogFile {
 
     /// Returns the index/sequence number of the last entry in the log
     pub fn last_index(&self) -> u64 {
-        self.first_index + self.len - 1
+        let last_index = self.first_index + self.len;
+        if last_index > 0 {
+            last_index - 1
+        } else {
+            0
+        }
     }
 
     /// Iterate through the log
-    pub fn iter<'s, R: RangeBounds<u64>>(&'s mut self, range: R) -> Result<LogIterator<'s>, LogError> {
+    pub fn iter<'s, R: RangeBounds<u64>>(
+        &'s mut self,
+        range: R,
+    ) -> Result<LogIterator<'s>, LogError> {
         if self.len == 0 {
             return Ok(LogIterator {
                 next: None,
-                last_index: self.first_index
+                last_index: self.first_index,
             });
         }
 
@@ -142,37 +146,38 @@ impl LogFile {
             Bound::Unbounded => self.last_index(),
             Bound::Included(x) if self.last_index() > *x => *x,
             Bound::Excluded(x) if self.last_index() > *x - 1 => *x - 1,
-            _ => return Err(LogError::OutOfBounds)
+            _ => return Err(LogError::OutOfBounds),
         };
 
         let start = match range.start_bound() {
             Bound::Unbounded => self.first_entry()?,
             Bound::Included(x) => self.seek(*x)?,
-            Bound::Excluded(x) => self.seek(*x + 1)?
+            Bound::Excluded(x) => self.seek(*x + 1)?,
         };
 
         Ok(LogIterator {
             next: Some(start),
-            last_index
+            last_index,
         })
     }
 
     /// Write the given log entry to the end of the log
     pub fn write<R: AsMut<[u8]>>(&mut self, entry: &mut R) -> io::Result<()> {
         let end_pos = self.file.seek(SeekFrom::End(0))?;
-        
+
         let entry = entry.as_mut();
-        
+
         let hash = {
             let mut hasher = crc32fast::Hasher::new();
             hasher.update(entry);
             &mut hasher.finalize().to_le_bytes()
         };
 
-        let result = 
-            self.file.write_all(&mut (entry.len() as u64).to_le_bytes())
-                .and_then(|_| self.file.write_all(entry))
-                .and_then(|_| self.file.write_all(hash));
+        let result = self
+            .file
+            .write_all(&mut (entry.len() as u64).to_le_bytes())
+            .and_then(|_| self.file.write_all(entry))
+            .and_then(|_| self.file.write_all(hash));
 
         if result.is_ok() {
             self.len += 1;
@@ -180,7 +185,7 @@ impl LogFile {
             // Trim the data written.
             self.file.set_len(end_pos + 1)?;
         }
-        
+
         result
     }
 
@@ -192,12 +197,9 @@ impl LogFile {
     /// Open the log. Takes out an advisory lock.
     ///
     /// This is O(n): we have to iterate to the end of the log in order to clean interrupted writes and determine the length of the log
-    pub fn open<P: AsRef<std::path::Path>>(
-        path: P,
-    ) -> Result<LogFile, LogError> {
+    pub fn open<P: AsRef<std::path::Path>>(path: P) -> Result<LogFile, LogError> {
         let mut file = AdvisoryFileLock::new(&path, advisory_lock::FileLockMode::Exclusive)?;
         let path = path.as_ref().to_owned();
-
 
         let file_size = file.metadata()?.len();
         let mut entries: u64 = 0;
@@ -222,16 +224,15 @@ impl LogFile {
 
             file.set_len(pos)?;
         } else {
-            file.write_all(&mut [0;8][..])?;
+            file.write_all(&mut [0; 8][..])?;
             file.set_len(8)?;
         }
-
 
         Ok(LogFile {
             path,
             file,
             first_index,
-            len: entries
+            len: entries,
         })
     }
 
@@ -249,7 +250,10 @@ impl LogFile {
 
         let mut temp_file_path = std::env::temp_dir().to_path_buf();
         temp_file_path.set_file_name(format!("log-{}", rand::random::<u32>()));
-        let mut new_file = AdvisoryFileLock::new(temp_file_path.as_path(), advisory_lock::FileLockMode::Exclusive)?;
+        let mut new_file = AdvisoryFileLock::new(
+            temp_file_path.as_path(),
+            advisory_lock::FileLockMode::Exclusive,
+        )?;
 
         new_file.write_all(&mut new_start_index.to_le_bytes())?;
         io::copy(&mut *self.file, &mut *new_file)?;
@@ -277,7 +281,6 @@ impl LogFile {
     }
 }
 
-
 #[derive(Debug, Error)]
 pub enum LogError {
     #[error("Bad checksum")]
@@ -285,7 +288,11 @@ pub enum LogError {
     #[error("Out of bounds")]
     OutOfBounds,
     #[error("{0}")]
-    IoError(#[source] #[from] io::Error),
+    IoError(
+        #[source]
+        #[from]
+        io::Error,
+    ),
     #[error("the log is locked")]
     AlreadyLocked,
 }
@@ -294,7 +301,7 @@ impl From<advisory_lock::FileLockError> for LogError {
     fn from(err: advisory_lock::FileLockError) -> Self {
         match err {
             advisory_lock::FileLockError::IOError(err) => LogError::IoError(err),
-            advisory_lock::FileLockError::AlreadyLocked => LogError::AlreadyLocked
+            advisory_lock::FileLockError::AlreadyLocked => LogError::AlreadyLocked,
         }
     }
 }
@@ -305,7 +312,7 @@ impl From<advisory_lock::FileLockError> for LogError {
 /// start of the log entry.
 pub struct LogEntry<'l> {
     log: &'l mut LogFile,
-    index: u64
+    index: u64,
 }
 
 impl<'l> LogEntry<'l> {
@@ -315,19 +322,21 @@ impl<'l> LogEntry<'l> {
 
     /// Reads into the io::Write and returns the next log entry if in-bounds.
     pub fn read_to_next<W: Write>(self, write: &mut W) -> Result<Option<LogEntry<'l>>, LogError> {
-        let LogEntry {log, index} = self;
+        let LogEntry { log, index } = self;
         let len = log.file.read_u64()?;
 
         let mut hasher = crc32fast::Hasher::new();
 
         {
-            let mut bytes_left: usize = len.try_into().expect("Log entry is too large to read on a 32 bit platform.");
+            let mut bytes_left: usize = len
+                .try_into()
+                .expect("Log entry is too large to read on a 32 bit platform.");
             let mut buf = [0; 8 * 1024];
 
             while bytes_left > 0 {
                 let read = bytes_left.min(buf.len());
                 let read = log.file.read(&mut buf[..read])?;
-                
+
                 hasher.update(&buf[..read]);
                 write.write_all(&buf[..read])?;
 
@@ -346,7 +355,7 @@ impl<'l> LogEntry<'l> {
         if log.first_index + log.len > next_index {
             Ok(Some(LogEntry {
                 log,
-                index: next_index
+                index: next_index,
             }))
         } else {
             Ok(None)
@@ -355,29 +364,30 @@ impl<'l> LogEntry<'l> {
 
     /// Seek forwards to the index. Only forwards traversal is allowed.
     pub fn seek(self, to_index: u64) -> Result<LogEntry<'l>, LogError> {
-        let LogEntry {log, index} = self;
+        let LogEntry { log, index } = self;
 
         if to_index > log.first_index + log.len || to_index < index {
-            return Err(LogError::OutOfBounds)
+            return Err(LogError::OutOfBounds);
         }
 
         for _ in index..to_index {
             let len = log.file.read_u64()?;
 
             // Move forwards through the length of the current log entry and the 4 byte checksum
-            log.file.seek(SeekFrom::Current((len + 4).try_into().unwrap()))?;
+            log.file
+                .seek(SeekFrom::Current((len + 4).try_into().unwrap()))?;
         }
 
         Ok(LogEntry {
             log,
-            index: to_index
+            index: to_index,
         })
     }
 }
 
 pub struct LogIterator<'l> {
     next: Option<LogEntry<'l>>,
-    last_index: u64
+    last_index: u64,
 }
 
 impl<'l> Iterator for LogIterator<'l> {
@@ -386,19 +396,19 @@ impl<'l> Iterator for LogIterator<'l> {
     fn next(&mut self) -> Option<Self::Item> {
         let entry = self.next.take()?;
 
-        if entry.index > self.last_index { return None };
+        if entry.index > self.last_index {
+            return None;
+        };
 
         let mut content = Vec::new();
 
-        Some(
-            match entry.read_to_next(&mut content) {
-                Ok(next) => {
-                    self.next = next;
-                    Ok(content)
-                },
-                Err(err) => Err(err)
+        Some(match entry.read_to_next(&mut content) {
+            Ok(next) => {
+                self.next = next;
+                Ok(content)
             }
-        )
+            Err(err) => Err(err),
+        })
     }
 }
 
@@ -409,12 +419,12 @@ trait ReadExt {
 
 impl<R: Read> ReadExt for R {
     fn read_u64(&mut self) -> Result<u64, io::Error> {
-        let mut bytes = [0;8];
+        let mut bytes = [0; 8];
         self.read_exact(&mut bytes)?;
         Ok(u64::from_le_bytes(bytes))
     }
     fn read_u32(&mut self) -> Result<u32, io::Error> {
-        let mut bytes = [0;4];
+        let mut bytes = [0; 4];
         self.read_exact(&mut bytes)?;
         Ok(u32::from_le_bytes(bytes))
     }
@@ -430,10 +440,7 @@ mod tests {
 
         let _ = std::fs::remove_file(path);
 
-        let entries = & [
-            b"test".to_vec(),
-            b"foobar".to_vec()
-        ];
+        let entries = &[b"test".to_vec(), b"foobar".to_vec()];
 
         {
             let mut log = LogFile::open(path).unwrap();
@@ -455,11 +462,8 @@ mod tests {
             // test after closing and reopening
             let mut log = LogFile::open(path).unwrap();
 
+            let read = log.iter(..).unwrap().map(|entry| entry.unwrap());
 
-            let read= log.iter(..).unwrap().map(|entry| {
-                entry.unwrap()
-            });
-        
             assert!(read.eq(entries.to_vec()));
         }
 
@@ -478,13 +482,12 @@ mod tests {
             let mut log = LogFile::open(path).unwrap();
 
             let entry = log.seek(1).unwrap();
-            
+
             entry.seek(0).err().expect("Cannot seek backwards");
         }
 
         std::fs::remove_file(path).unwrap();
     }
-
 
     #[test]
     fn compaction() {
@@ -492,7 +495,7 @@ mod tests {
 
         let _ = std::fs::remove_file(path);
 
-        let entries = & [
+        let entries = &[
             b"test".to_vec(),
             b"foobar".to_vec(),
             b"bbb".to_vec(),
@@ -500,7 +503,7 @@ mod tests {
             b"11".to_vec(),
             b"222".to_vec(),
             [9; 200].to_vec(),
-            b"bar".to_vec()
+            b"bar".to_vec(),
         ];
 
         {
@@ -516,7 +519,11 @@ mod tests {
             log.compact(4).unwrap();
 
             assert_eq!(log.first_index(), 4);
-            assert!(log.iter(..).unwrap().map(|a| a.unwrap()).eq(entries[4..].to_vec().into_iter()));
+            assert!(log
+                .iter(..)
+                .unwrap()
+                .map(|a| a.unwrap())
+                .eq(entries[4..].to_vec().into_iter()));
 
             log.flush().unwrap();
         }
@@ -524,7 +531,11 @@ mod tests {
         {
             let mut log = LogFile::open(path).unwrap();
             assert_eq!(log.first_index(), 4);
-            assert!(log.iter(..).unwrap().map(|a| a.unwrap()).eq(entries[4..].to_vec().into_iter()));
+            assert!(log
+                .iter(..)
+                .unwrap()
+                .map(|a| a.unwrap())
+                .eq(entries[4..].to_vec().into_iter()));
         }
 
         std::fs::remove_file(path).unwrap();
@@ -536,7 +547,7 @@ mod tests {
 
         let _ = std::fs::remove_file(path);
 
-        let entries = & [
+        let entries = &[
             b"test".to_vec(),
             b"foobar".to_vec(),
             b"bbb".to_vec(),
@@ -544,7 +555,7 @@ mod tests {
             b"11".to_vec(),
             b"222".to_vec(),
             [9; 200].to_vec(),
-            b"bar".to_vec()
+            b"bar".to_vec(),
         ];
 
         {
@@ -578,15 +589,11 @@ mod tests {
 
     #[test]
     fn handles_trimmed_wal() {
-
         let path = std::path::Path::new("./wal-log-test-trimmed");
 
         let _ = std::fs::remove_file(path);
 
-        let entries = & [
-            b"test".to_vec(),
-            b"foobar".to_vec()
-        ];
+        let entries = &[b"test".to_vec(), b"foobar".to_vec()];
 
         {
             let mut log = LogFile::open(path).unwrap();
@@ -598,24 +605,24 @@ mod tests {
 
             log.flush().unwrap();
         }
-        
+
         {
             // trim last log entry to cause chaos
-            let mut file = std::fs::OpenOptions::new().write(true).read(true).open(path).unwrap();
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .read(true)
+                .open(path)
+                .unwrap();
             file.set_len(38).unwrap();
             file.flush().unwrap();
         }
-        
 
         {
             // test after closing and reopening
             let mut log = LogFile::open(path).unwrap();
 
+            let read = log.iter(..).unwrap().map(|entry| entry.unwrap());
 
-            let read= log.iter(..).unwrap().map(|entry| {
-                entry.unwrap()
-            });
-        
             assert!(read.eq(entries[..1].to_vec()));
         }
 


### PR DESCRIPTION
get `thread 'main' panicked at 'attempt to subtract with overflow', ../simple_wal-0.3.0/src/lib.rs:129:9` on empty wal. Fix it.