### PR TITLE
fix last_index() on empty wal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,12 @@ impl LogFile {
 
     /// Returns the index/sequence number of the last entry in the log
     pub fn last_index(&self) -> u64 {
-        self.first_index + self.len - 1
+        let last_index = self.first_index + self.len;
+        if last_index > 0 {
+            last_index - 1
+        } else {
+            0
+        }
     }
 
     /// Iterate through the log
@@ -619,6 +624,18 @@ mod tests {
             let read = log.iter(..).unwrap().map(|entry| entry.unwrap());
 
             assert!(read.eq(entries[..1].to_vec()));
+        }
+
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn last_index_on_empty() {
+        let path = std::path::Path::new("./wal-log-test-last-index");
+        
+        {
+            let log = LogFile::open(path).unwrap();
+            assert_eq!(log.last_index(), 0);
         }
 
         std::fs::remove_file(path).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,11 @@ impl LogFile {
         self.first_index
     }
 
+    /// Return if there are any entries in the log
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
     /// Returns the index/sequence number of the last entry in the log
     pub fn last_index(&self) -> u64 {
         let last_index = self.first_index + self.len;
@@ -632,7 +637,7 @@ mod tests {
     #[test]
     fn last_index_on_empty() {
         let path = std::path::Path::new("./wal-log-test-last-index");
-        
+
         {
             let log = LogFile::open(path).unwrap();
             assert_eq!(log.last_index(), 0);


### PR DESCRIPTION
get thread 'main' panicked at 'attempt to subtract with overflow', ../simple_wal-0.3.0/src/lib.rs:129:9 on empty wal. Fix it.